### PR TITLE
Remove unnecessary nonnegative constraint in msgPackSchema

### DIFF
--- a/packages/ntcore-ts-client/src/lib/types/schemas.ts
+++ b/packages/ntcore-ts-client/src/lib/types/schemas.ts
@@ -225,7 +225,7 @@ export const msgPackValueSchema = z.union([
 /** Schema for a binary message in the msgpack format. */
 export const msgPackSchema = z.tuple([
   z.union([z.number().int().nonnegative(), z.literal(-1)]),
-  z.number().int().nonnegative(),
+  z.number().int(),
   typeNumSchema,
   msgPackValueSchema,
 ]);


### PR DESCRIPTION
From the spec

> Messages shall consist of (in this order):
> - Topic/Publisher ID: unsigned integer, or -1 (RTT measurement)
> - Timestamp: integer microseconds
> - Data type: unsigned integer
> - Data value (see below)

The spec allows negative values for the timestamp. For some reason NetworkTables was sending negative timestamps for me and this fixed it. I haven't done rigorous testing but subscribers are working. The subscription is persistent which is probably related to the negative timestamp but that is an issue for WPILib.