### PR TITLE
fix(3.1.3): correct kArrayBuffer value in NetworkTablesTypeInfos

### DIFF
--- a/packages/ntcore-ts-client/CHANGELOG.md
+++ b/packages/ntcore-ts-client/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 Note: there may be breaking changes between each beta version, but if a breaking change is introduced out of beta, it will be a major version change
 
+## 3.1.3
+
+- Hotfix: Fix `raw` type number to be `5` instead of `3`
+- Updated dependencies
+
+### Non-library changes
+
+- Swap from jest to vitest
+
 ## 3.1.2
 
 - Hotfix: WPILib 2025.2.1 needs a subscription after publish to receive the announcement. Implements this hotfix and other small null-check fixes.

--- a/packages/ntcore-ts-client/package.json
+++ b/packages/ntcore-ts-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ntcore-ts-client",
-  "version": "3.1.2",
+  "version": "3.1.3",
   "license": "MIT",
   "keywords": [
     "ntcore",

--- a/packages/ntcore-ts-client/src/lib/types/types.spec.ts
+++ b/packages/ntcore-ts-client/src/lib/types/types.spec.ts
@@ -19,7 +19,7 @@ describe('NetworkTablesTypeInfos', () => {
     expect(NetworkTablesTypeInfos.kDouble).toEqual([1, 'double']);
     expect(NetworkTablesTypeInfos.kInteger).toEqual([2, 'int']);
     expect(NetworkTablesTypeInfos.kString).toEqual([4, 'string']);
-    expect(NetworkTablesTypeInfos.kArrayBuffer).toEqual([3, 'raw']);
+    expect(NetworkTablesTypeInfos.kArrayBuffer).toEqual([5, 'raw']);
     expect(NetworkTablesTypeInfos.kBooleanArray).toEqual([16, 'boolean[]']);
     expect(NetworkTablesTypeInfos.kDoubleArray).toEqual([17, 'double[]']);
     expect(NetworkTablesTypeInfos.kIntegerArray).toEqual([18, 'int[]']);

--- a/packages/ntcore-ts-client/src/lib/types/types.ts
+++ b/packages/ntcore-ts-client/src/lib/types/types.ts
@@ -58,7 +58,7 @@ export class NetworkTablesTypeInfos {
   static readonly kDouble: NetworkTablesTypeInfo = [1, 'double'];
   static readonly kInteger: NetworkTablesTypeInfo = [2, 'int'];
   static readonly kString: NetworkTablesTypeInfo = [4, 'string'];
-  static readonly kArrayBuffer: NetworkTablesTypeInfo = [3, 'raw'];
+  static readonly kArrayBuffer: NetworkTablesTypeInfo = [5, 'raw'];
   static readonly kBooleanArray: NetworkTablesTypeInfo = [16, 'boolean[]'];
   static readonly kDoubleArray: NetworkTablesTypeInfo = [17, 'double[]'];
   static readonly kIntegerArray: NetworkTablesTypeInfo = [18, 'int[]'];


### PR DESCRIPTION
This pull request for the `ntcore-ts-client` package includes a version bump to `3.1.3`, a hotfix for the `raw` type number, a test update to reflect this fix, and a switch from Jest to Vitest for testing. Below are the key changes:

### Hotfix for `raw` type number:

* Updated the `kArrayBuffer` type in `NetworkTablesTypeInfos` to use `5` instead of `3` as the `raw` type number in `types.ts`.
* Updated the corresponding test in `types.spec.ts` to validate the new `raw` type number.

### Version and dependency updates:

* Bumped the package version from `3.1.2` to `3.1.3` in `package.json`.
* Added a changelog entry for version `3.1.3`, documenting the hotfix and the switch to Vitest.